### PR TITLE
Fixed: 修复通知校验签名失败

### DIFF
--- a/lib/alipay.ts
+++ b/lib/alipay.ts
@@ -408,9 +408,8 @@ class AlipaySdk {
     }
 
     const signArgs = { ...postData };
-    // 除去sign、sign_type 皆是待验签的参数。
+    // 除去sign 皆是待验签的参数。
     delete signArgs.sign;
-    delete signArgs.sign_type;
 
     const decodeSign = Object.keys(signArgs).sort().filter(val => val).map((key) => {
       let value = signArgs[key];


### PR DESCRIPTION
### 官网最新的文档，sign_type已为签名字段
### 以下为官方文档摘抄部分
> 地址：https://docs.open.alipay.com/197/105240

开发者接收到该消息之后，需要使用支付宝的公钥对签名作验证，以确保该消息来源可靠。
将支付宝返回的POST参数(不包含sign参数)做字母排序，组成query类型的字符串，比如上文的POST请求组成的query类型字符串为：
```
biz_content=<?xml version="1.0" encoding="gbk"?><XML><AppId><![CDATA[2014072300007148]]></AppId><FromUserId></FromUserId><CreateTime><![CDATA[1406083506817]]></CreateTime><MsgType><![CDATA[event]]></MsgType><EventType><![CDATA[verifygw]]></EventType><ActionParam></ActionParam><AgreementId></AgreementId><AccountNo></AccountNo></XML>&charset=GBK&service=alipay.service.check&sign_type=RSA2
```
